### PR TITLE
ImageSharp updated to actual "1.0.0-unstable1162" version

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,10 +26,10 @@
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.14.4" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.3.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-dev003209" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-unstable1162" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Update="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.5.2.0" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.console" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />

--- a/ImageSharp.Textures.sln
+++ b/ImageSharp.Textures.sln
@@ -37,7 +37,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageSharp.Textures.Interac
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		tests\Images\Images.projitems*{17fcbd4d-d232-45e8-876f-dfbc2fad52cf}*SharedItemsImports = 5
+		tests\Images\Images.projitems*{18be79b6-6b95-4ed7-a963-ad75f6cb9f3c}*SharedItemsImports = 5
 		tests\Images\Images.projitems*{68a8cc40-6aed-4e96-b524-31b1158fdeea}*SharedItemsImports = 13
+		tests\Images\Images.projitems*{b159ffd1-e646-42d0-892c-4abf69103712}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/ImageSharp.Textures/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp.Textures/Common/Extensions/StreamExtensions.cs
@@ -6,7 +6,7 @@ namespace SixLabors.ImageSharp.Textures
     using System;
     using System.Buffers;
     using System.IO;
-    using SixLabors.Memory;
+    using SixLabors.ImageSharp.Memory;
 
     /// <summary>
     /// Extension methods for the <see cref="Stream"/> type.

--- a/src/ImageSharp.Textures/Configuration.cs
+++ b/src/ImageSharp.Textures/Configuration.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Textures
     using SixLabors.ImageSharp.Textures.Formats;
     using SixLabors.ImageSharp.Textures.Formats.Dds;
     using SixLabors.ImageSharp.Textures.IO;
-    using SixLabors.Memory;
+    using SixLabors.ImageSharp.Memory;
 
     /// <summary>
     /// Provides configuration code which allows altering default behaviour or extending the library.

--- a/src/ImageSharp.Textures/Formats/Dds/DdsDecoder.cs
+++ b/src/ImageSharp.Textures/Formats/Dds/DdsDecoder.cs
@@ -20,7 +20,7 @@ https://docs.microsoft.com/en-us/windows/uwp/gaming/complete-code-for-ddstexture
     {
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             throw new NotSupportedException();
         }

--- a/src/ImageSharp.Textures/Formats/Dds/DdsDecoderCore.cs
+++ b/src/ImageSharp.Textures/Formats/Dds/DdsDecoderCore.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Textures.Formats.Dds
     using SixLabors.ImageSharp.Textures.Formats.Dds.Extensions;
     using SixLabors.ImageSharp.Textures.Formats.Dds.Processing;
     using SixLabors.ImageSharp.Textures.TextureFormats;
-    using SixLabors.Memory;
+    using SixLabors.ImageSharp.Memory;
 
     internal sealed class DdsDecoderCore
     {

--- a/src/ImageSharp.Textures/Texture.Decode.cs
+++ b/src/ImageSharp.Textures/Texture.Decode.cs
@@ -7,7 +7,7 @@ namespace SixLabors.ImageSharp.Textures
     using System.IO;
     using System.Linq;
     using SixLabors.ImageSharp.Textures.Formats;
-    using SixLabors.Memory;
+    using SixLabors.ImageSharp.Memory;
 
     /// <content>
     /// Adds static methods allowing the decoding of new images.

--- a/tests/ImageSharp.Textures.InteractiveTest/ApplicationManager.cs
+++ b/tests/ImageSharp.Textures.InteractiveTest/ApplicationManager.cs
@@ -21,7 +21,7 @@ namespace Phoenix.Import.Application
             lock (lockObject)
             {
                 Texture texture = GraphicsDevice.ResourceFactory.CreateTexture(TextureDescription.Texture2D((uint)image.Width, (uint)image.Height, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled));
-                fixed (void* pin = &MemoryMarshal.GetReference(image.GetPixelSpan()))
+                fixed (void* pin = &MemoryMarshal.GetReference(image.GetPixelRowSpan(0)))
                 {
                     GraphicsDevice.UpdateTexture(texture, (IntPtr)pin, (uint)(4 * image.Width * image.Height), 0, 0, 0, (uint)image.Width, (uint)image.Height, 1, 0, 0);
                 }

--- a/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/ExactImageComparer.cs
+++ b/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/ExactImageComparer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Numerics;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
 {

--- a/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/Exceptions/ImageDimensionsMismatchException.cs
+++ b/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/Exceptions/ImageDimensionsMismatchException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Primitives;
-
 namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison.Exceptions
 {
     public class ImageDimensionsMismatchException : ImagesSimilarityException

--- a/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/ImageComparer.cs
+++ b/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/ImageComparer.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison.Exceptions;
-using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
 {
@@ -35,8 +34,8 @@ namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
         public abstract ImageSimilarityReport<TPixelA, TPixelB> CompareImages<TPixelA, TPixelB>(
             Image<TPixelA> expected,
             Image<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>;
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>;
     }
 
     public static class ImageComparerExtensions
@@ -45,8 +44,8 @@ namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
             this ImageComparer comparer,
             Image<TPixelA> expected,
             Image<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             return comparer.CompareImages(expected, actual);
         }
@@ -55,8 +54,8 @@ namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
             this ImageComparer comparer,
             Image<TPixelA> expected,
             Image<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             if (expected.Size() != actual.Size())
             {
@@ -80,8 +79,8 @@ namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
             Image<TPixelA> expected,
             Image<TPixelB> actual,
             Rectangle ignoredRegion)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             if (expected.Size() != actual.Size())
             {

--- a/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/ImageSimilarityReport.cs
+++ b/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/ImageSimilarityReport.cs
@@ -82,8 +82,8 @@ namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
     }
 
     public class ImageSimilarityReport<TPixelA, TPixelB> : ImageSimilarityReport
-        where TPixelA : struct, IPixel<TPixelA>
-        where TPixelB : struct, IPixel<TPixelB>
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB>
     {
         public ImageSimilarityReport(
             Image<TPixelA> expectedImage,

--- a/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/PixelDifference.cs
+++ b/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/PixelDifference.cs
@@ -1,6 +1,4 @@
 using System.Numerics;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
 {

--- a/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/TolerantImageComparer.cs
+++ b/tests/ImageSharp.Textures.Tests/TestUtilities/ImageComparison/TolerantImageComparer.cs
@@ -2,10 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
-
-using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Textures.Tests.TestUtilities.ImageComparison
 {


### PR DESCRIPTION
At least now project compiles. Still many unit tests fail.