### PR TITLE
Fix potential overflow in HDR pixel formats

### DIFF
--- a/src/ImageSharp.Textures/PixelFormats/Generated/D32_FLOAT_S8X24_UINT.cs
+++ b/src/ImageSharp.Textures/PixelFormats/Generated/D32_FLOAT_S8X24_UINT.cs
@@ -171,9 +171,8 @@ namespace SixLabors.ImageSharp.Textures.PixelFormats
         private static ulong Pack(ref Vector2 vector)
         {
             vector = Vector2.Clamp(vector, Vector2.Zero, Vector2.One);
-            return (ulong)(
-                (uint)FloatHelper.PackFloatToFloat32(vector.X)
-                | (((uint)Math.Round(vector.Y * 255F) & 255) << 32));
+            return (ulong)FloatHelper.PackFloatToFloat32(vector.X)
+                | ((ulong)((uint)Math.Round(vector.Y * 255F) & 255) << 32);
         }
     }
 }

--- a/src/ImageSharp.Textures/PixelFormats/Generated/PixelGenerator.ignore
+++ b/src/ImageSharp.Textures/PixelFormats/Generated/PixelGenerator.ignore
@@ -904,11 +904,10 @@ namespace SixLabors.ImageSharp.Textures.PixelFormats
         private static ulong Pack(ref Vector4 vector)
         {
             vector = Vector4.Clamp(vector, Vector4.Zero, Vector4.One);
-            return (ulong)(
-                (uint)FloatHelper.PackFloatToFloat16(vector.X)
-                | ((uint)FloatHelper.PackFloatToFloat16(vector.Y) << 16)
-                | ((uint)FloatHelper.PackFloatToFloat16(vector.Z) << 32)
-                | ((uint)FloatHelper.PackFloatToFloat16(vector.W) << 48));
+            return (ulong)FloatHelper.PackFloatToFloat16(vector.X)
+                | ((ulong)FloatHelper.PackFloatToFloat16(vector.Y) << 16)
+                | ((ulong)FloatHelper.PackFloatToFloat16(vector.Z) << 32)
+                | ((ulong)FloatHelper.PackFloatToFloat16(vector.W) << 48);
         }
     }
 }
@@ -1598,9 +1597,8 @@ namespace SixLabors.ImageSharp.Textures.PixelFormats
         private static ulong Pack(ref Vector2 vector)
         {
             vector = Vector2.Clamp(vector, Vector2.Zero, Vector2.One);
-            return (ulong)(
-                (uint)FloatHelper.PackFloatToFloat32(vector.X)
-                | (((uint)Math.Round(vector.Y * 255F) & 255) << 32));
+            return (ulong)FloatHelper.PackFloatToFloat32(vector.X)
+                | ((ulong)((uint)Math.Round(vector.Y * 255F) & 255) << 32);
         }
     }
 }

--- a/src/ImageSharp.Textures/PixelFormats/Generated/Rgba64Float.cs
+++ b/src/ImageSharp.Textures/PixelFormats/Generated/Rgba64Float.cs
@@ -171,11 +171,10 @@ namespace SixLabors.ImageSharp.Textures.PixelFormats
         private static ulong Pack(ref Vector4 vector)
         {
             vector = Vector4.Clamp(vector, Vector4.Zero, Vector4.One);
-            return (ulong)(
-                (uint)FloatHelper.PackFloatToFloat16(vector.X)
-                | ((uint)FloatHelper.PackFloatToFloat16(vector.Y) << 16)
-                | ((uint)FloatHelper.PackFloatToFloat16(vector.Z) << 32)
-                | ((uint)FloatHelper.PackFloatToFloat16(vector.W) << 48));
+            return (ulong)FloatHelper.PackFloatToFloat16(vector.X)
+                | ((ulong)FloatHelper.PackFloatToFloat16(vector.Y) << 16)
+                | ((ulong)FloatHelper.PackFloatToFloat16(vector.Z) << 32)
+                | ((ulong)FloatHelper.PackFloatToFloat16(vector.W) << 48);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Textures/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Fixes integer overflow in three generated pixel format files. Casting to unit could result in an overflow when shifting, widening to a long allows for correct shifting without overflow.

I have not included regression tests in this PR, they will be part of the HDR support for ASTC which will cover this indirectly.